### PR TITLE
Add the path of dynamic-link library to script/local.sh

### DIFF
--- a/script/local.sh
+++ b/script/local.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../third_party/lib
 if [ $# -lt 3 ]; then
     echo "usage: ./local.sh num_servers num_workers app_conf [args]"
     exit -1;


### PR DESCRIPTION
If not, there will be a error as follows while running "./local.sh 1 4 ../config/rcv1/batch_l1lr.conf".

`../bin/ps: error while loading shared libraries: libgflags.so.2: cannot open shared object file: No such file or directory`
