### PR TITLE
Caffe integration attempt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.pb.cc
 .*
 /script/van*
+Makefile.config

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ build/caffe: build/app/caffe/caffe_main.o $(PS_LIB)
 build/caffe_sync: build/app/caffe/caffe_synced.o $(PS_LIB)
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@	
 
+caffe_all: build/caffe build/caffe_sync
+
 sys_srcs	= $(wildcard src/util/*.cc) $(wildcard src/data/*.cc) \
 			  $(wildcard src/system/*.cc) $(wildcard src/filter/*.cc)
 sys_protos	= $(wildcard src/*/proto/*.proto)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 WARN = -Wall -Wno-unused-function -finline-functions -Wno-sign-compare #-Wconversion
 INCPATH = -I./src -I$(THIRD_PATH)/include -I/usr/include/eigen3 -I$(CAFFE_PATH)/include -I$(CAFFE_PATH)/build/src  -I$(CUDA_PATH)/include
 CFLAGS = -std=c++0x $(WARN) $(OPT) $(INCPATH)
-LDFLAGS += $(THIRD_LIB) -lpthread -lrt -lcaffe -L$(CAFFE_PATH)/build/lib
+LDFLAGS += $(THIRD_LIB) -lpthread -lrt -lcaffe -L$(CAFFE_PATH)/build/lib -Wl,-rpath=$(CAFFE_PATH)/build/lib -Wl,-rpath=$(THIRD_PATH)/lib
 
 PS_LIB = build/libps.a
 PS_MAIN = build/libpsmain.a
@@ -34,6 +34,9 @@ app: build/ps
 
 build/hello: build/app/hello_world/main.o $(PS_LIB) $(PS_MAIN)
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@
+
+build/caffe: build/app/caffe/caffe_main.o $(PS_LIB)
+	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@	
 
 sys_srcs	= $(wildcard src/util/*.cc) $(wildcard src/data/*.cc) \
 			  $(wildcard src/system/*.cc) $(wildcard src/filter/*.cc)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CC = g++
 # OPT = -O0 -ggdb
 OPT = -O3 -ggdb
 
-THIRD_PATH=$(shell pwd)/third_party
+THIRD_PATH=$(shell pwd -L )/third_party
 
 STATIC_THIRD_LIB=0
 ifeq ($(STATIC_THIRD_LIB), 1)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 WARN = -Wall -Wno-unused-function -finline-functions -Wno-sign-compare #-Wconversion
 INCPATH = -I./src -I$(THIRD_PATH)/include -I/usr/include/eigen3 -I$(CAFFE_PATH)/include -I$(CAFFE_PATH)/build/src  -I$(CUDA_PATH)/include
 CFLAGS = -std=c++0x $(WARN) $(OPT) $(INCPATH)
-LDFLAGS += $(THIRD_LIB) -lpthread -lrt -lcaffe -L$(CAFFE_PATH)/build/lib -Wl,-rpath=$(CAFFE_PATH)/build/lib -Wl,-rpath=$(THIRD_PATH)/lib
+LDFLAGS += $(THIRD_LIB) -lboost_thread -lboost_system -lpthread -lrt -lcaffe -L$(CAFFE_PATH)/build/lib -Wl,-rpath=$(CAFFE_PATH)/build/lib -Wl,-rpath=$(THIRD_PATH)/lib
 
 PS_LIB = build/libps.a
 PS_MAIN = build/libpsmain.a
@@ -41,7 +41,10 @@ build/caffe: build/app/caffe/caffe_main.o $(PS_LIB)
 build/caffe_sync: build/app/caffe/caffe_synced.o $(PS_LIB)
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@	
 
-caffe_all: build/caffe build/caffe_sync
+build/caffe_share: build/app/caffe/caffe_share.o $(PS_LIB)
+	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@	
+
+caffe_all: build/caffe build/caffe_sync build/caffe_share
 
 sys_srcs	= $(wildcard src/util/*.cc) $(wildcard src/data/*.cc) \
 			  $(wildcard src/system/*.cc) $(wildcard src/filter/*.cc)

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,10 @@ build/caffe_sync: build/app/caffe/caffe_synced.o $(PS_LIB)
 build/caffe_share: build/app/caffe/caffe_share.o $(PS_LIB)
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@	
 
-caffe_all: build/caffe build/caffe_sync build/caffe_share
+build/caffe_async_share: build/app/caffe/caffe_async_share.o $(PS_LIB)
+	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@	
+
+caffe_all: build/caffe build/caffe_sync build/caffe_share build/caffe_async_share
 
 sys_srcs	= $(wildcard src/util/*.cc) $(wildcard src/data/*.cc) \
 			  $(wildcard src/system/*.cc) $(wildcard src/filter/*.cc)

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
+
+CONFIG_FILE := Makefile.config
+include $(CONFIG_FILE)
+
 CC = g++
 
 # OPT = -O0 -ggdb
 OPT = -O3 -ggdb
 
 THIRD_PATH=$(shell pwd)/third_party
+
 STATIC_THIRD_LIB=0
 ifeq ($(STATIC_THIRD_LIB), 1)
 THIRD_LIB=$(addprefix $(THIRD_PATH)/lib/, libgflags.a libzmq.a libprotobuf.a libglog.a libz.a  libsnappy.a)
@@ -13,9 +18,9 @@ endif
 # THIRD_LIB+=-ltcmalloc_and_profiler
 
 WARN = -Wall -Wno-unused-function -finline-functions -Wno-sign-compare #-Wconversion
-INCPATH = -I./src -I$(THIRD_PATH)/include
+INCPATH = -I./src -I$(THIRD_PATH)/include -I/usr/include/eigen3 -I$(CAFFE_PATH)/include -I$(CAFFE_PATH)/build/src  -I$(CUDA_PATH)/include
 CFLAGS = -std=c++0x $(WARN) $(OPT) $(INCPATH)
-LDFLAGS += $(THIRD_LIB) -lpthread -lrt
+LDFLAGS += $(THIRD_LIB) -lpthread -lrt -lcaffe -L$(CAFFE_PATH)/build/lib
 
 PS_LIB = build/libps.a
 PS_MAIN = build/libpsmain.a

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ include $(CONFIG_FILE)
 
 CC = g++
 
-# OPT = -O0 -ggdb
-OPT = -O3 -ggdb
+OPT = -O0 -ggdb -DDEBUG
+# OPT = -O3 -ggdb
 
 THIRD_PATH=$(shell pwd -L )/third_party
 
@@ -36,6 +36,9 @@ build/hello: build/app/hello_world/main.o $(PS_LIB) $(PS_MAIN)
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@
 
 build/caffe: build/app/caffe/caffe_main.o $(PS_LIB)
+	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@	
+
+build/caffe_sync: build/app/caffe/caffe_synced.o $(PS_LIB)
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@	
 
 sys_srcs	= $(wildcard src/util/*.cc) $(wildcard src/data/*.cc) \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ STATIC_THIRD_LIB=0
 ifeq ($(STATIC_THIRD_LIB), 1)
 THIRD_LIB=$(addprefix $(THIRD_PATH)/lib/, libgflags.a libzmq.a libprotobuf.a libglog.a libz.a  libsnappy.a)
 else
-THIRD_LIB=-L$(THIRD_PATH)/lib -lgflags -lzmq -lprotobuf -lglog -lz -lsnappy
+THIRD_LIB=-L$(THIRD_PATH)/lib -lgflags -lzmq -lprotobuf -lglog -lz -lsnappy -L$(CUDA_PATH)/lib64 -lcudart
 endif
 # THIRD_LIB+=-ltcmalloc_and_profiler
 

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ include $(CONFIG_FILE)
 
 CC = g++
 
-OPT = -O0 -ggdb -DDEBUG
-# OPT = -O3 -ggdb
+# OPT = -O0 -ggdb -DDEBUG
+OPT = -O3 -ggdb
 
 THIRD_PATH=$(shell pwd -L )/third_party
 

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -1,0 +1,8 @@
+##
+
+# CUDA path for include
+CUDA_PATH := /usr/local/cuda
+
+# caffe source path
+# need to build caffe successfully
+CAFFE_PATH := /data/ML/caffe/caffe

--- a/conf/caffe.as.conf
+++ b/conf/caffe.as.conf
@@ -1,0 +1,17 @@
+# async shared
+PS_PATH /home/immars/work/ML/distributed/parameter_server/build/caffe_async_share
+PUSH 4
+PULL 8
+SCHEDULER 192.168.1.108
+
+SERVER 192.168.1.108 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML solver.maxmap.prototxt 0 snapshot/bvlc_maxmap_iter_1210000.solverstate
+# SERVER 192.168.1.108 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML solver.maxmap.prototxt 0
+WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML solver.maxmap.prototxt 0 W0,W1,W2,W3
+# WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W1 solver.maxmap.prototxt 1
+# WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W2 solver.maxmap.prototxt 2
+# WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W3 solver.maxmap.prototxt 3
+WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML solver.maxmap.prototxt 0 W0,W1,W2,W3
+# WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W1 solver.maxmap.prototxt 1
+# WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W2 solver.maxmap.prototxt 2
+# WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W3 solver.maxmap.prototxt 3
+

--- a/conf/caffe.conf
+++ b/conf/caffe.conf
@@ -1,0 +1,6 @@
+PS_PATH /home/immars/work/ML/distributed/parameter_server/build/caffe
+SCHEDULER 192.168.1.108
+
+SERVER 192.168.1.108 /home/immars/work/ML/caffe/caffe/models/bvlc_reference_caffenet/S0 solver.prototxt -1
+WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_reference_caffenet/W0 solver.prototxt 0
+WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_reference_caffenet/W1 solver.prototxt 1

--- a/conf/caffe.googlenet.conf
+++ b/conf/caffe.googlenet.conf
@@ -1,13 +1,16 @@
 PS_PATH /home/immars/work/ML/distributed/parameter_server/build/caffe
+PUSH 10
+PULL 10
 SCHEDULER 192.168.1.108
 
-SERVER 192.168.1.108 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML solver.adagrad.prototxt -1 snapshot/bvlc_googlenet_iter_10000.solverstate
-WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W0 solver.adagrad.prototxt 0
-WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W1 solver.adagrad.prototxt 1
-WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W2 solver.adagrad.prototxt 2
-WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W3 solver.adagrad.prototxt 3
-WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W0 solver.adagrad.prototxt 0
-WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W1 solver.adagrad.prototxt 1
-WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W2 solver.adagrad.prototxt 2
-WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W3 solver.adagrad.prototxt 3
+# SERVER 192.168.1.108 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML solver.adadelta.prototxt -1 snapshot/bvlc_googlenet_iter_220000.solverstate
+SERVER 192.168.1.108 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML solver.adadelta.s.prototxt -1 snapshot/bvlc_googlenet_iter_10000.solverstate
+WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W0 solver.adadelta.c.prototxt 0
+WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W1 solver.adadelta.c.prototxt 1
+WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W2 solver.adadelta.c.prototxt 2
+WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W3 solver.adadelta.c.prototxt 3
+WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W0 solver.adadelta.c.prototxt 0
+WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W1 solver.adadelta.c.prototxt 1
+WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W2 solver.adadelta.c.prototxt 2
+WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W3 solver.adadelta.c.prototxt 3
 

--- a/conf/caffe.googlenet.conf
+++ b/conf/caffe.googlenet.conf
@@ -1,10 +1,10 @@
-PS_PATH /home/immars/work/ML/distributed/parameter_server/build/caffe
-PUSH 10
-PULL 10
+PS_PATH /home/immars/work/ML/distributed/parameter_server/build/caffe_sync
+PUSH 8
+PULL 8
 SCHEDULER 192.168.1.108
 
 # SERVER 192.168.1.108 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML solver.adadelta.prototxt -1 snapshot/bvlc_googlenet_iter_220000.solverstate
-SERVER 192.168.1.108 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML solver.adadelta.s.prototxt -1 snapshot/bvlc_googlenet_iter_10000.solverstate
+SERVER 192.168.1.108 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML solver.adadelta.s.prototxt -1 snapshot/bvlc_googlenet_iter_140000.solverstate
 WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W0 solver.adadelta.c.prototxt 0
 WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W1 solver.adadelta.c.prototxt 1
 WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W2 solver.adadelta.c.prototxt 2

--- a/conf/caffe.googlenet.conf
+++ b/conf/caffe.googlenet.conf
@@ -1,0 +1,13 @@
+PS_PATH /home/immars/work/ML/distributed/parameter_server/build/caffe
+SCHEDULER 192.168.1.108
+
+SERVER 192.168.1.108 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML solver.adagrad.prototxt -1 snapshot/bvlc_googlenet_iter_10000.solverstate
+WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W0 solver.adagrad.prototxt 0
+WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W1 solver.adagrad.prototxt 1
+WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W2 solver.adagrad.prototxt 2
+WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W3 solver.adagrad.prototxt 3
+WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W0 solver.adagrad.prototxt 0
+WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W1 solver.adagrad.prototxt 1
+WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W2 solver.adagrad.prototxt 2
+WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W3 solver.adagrad.prototxt 3
+

--- a/conf/caffe.maxmap.conf
+++ b/conf/caffe.maxmap.conf
@@ -1,0 +1,15 @@
+PS_PATH /home/immars/work/ML/distributed/parameter_server/build/caffe_sync
+PUSH 8
+PULL 8
+SCHEDULER 192.168.1.108
+
+SERVER 192.168.1.108 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML solver.maxmap.prototxt -1
+WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W0 solver.maxmap.prototxt 0
+# WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W1 solver.maxmap.prototxt 1
+# WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W2 solver.maxmap.prototxt 2
+# WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W3 solver.maxmap.prototxt 3
+# WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W0 solver.maxmap.prototxt 0
+# WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W1 solver.maxmap.prototxt 1
+# WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W2 solver.maxmap.prototxt 2
+# WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W3 solver.maxmap.prototxt 3
+

--- a/conf/caffe.share.conf
+++ b/conf/caffe.share.conf
@@ -1,0 +1,15 @@
+PS_PATH /home/immars/work/ML/distributed/parameter_server/build/caffe_share
+PUSH 8
+PULL 8
+SCHEDULER 192.168.1.108
+
+SERVER 192.168.1.108 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML solver.maxmap.prototxt -1
+WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML solver.maxmap.prototxt -1 W0,W1,W2,W3
+# WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W1 solver.maxmap.prototxt 1
+# WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W2 solver.maxmap.prototxt 2
+# WORKER 192.168.1.110 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W3 solver.maxmap.prototxt 3
+WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML solver.maxmap.prototxt 0 W0,W1,W2,W3
+# WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W1 solver.maxmap.prototxt 1
+# WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W2 solver.maxmap.prototxt 2
+# WORKER 192.168.1.112 /home/immars/work/ML/caffe/caffe/models/bvlc_googlenet/ML/W3 solver.maxmap.prototxt 3
+

--- a/script/caffe_kill_lan.sh
+++ b/script/caffe_kill_lan.sh
@@ -12,16 +12,17 @@ conf=$1
 tmp=$( mktemp )
 grep -v ^# $conf > $tmp
 conf=$tmp
-
+app=$( grep PS_PATH $conf | awk -F'/' '{print $NF;}' )
+echo "app: $app"
 echo "kill local"
 
-killall caffe
+killall caffe || killall $app
 
 echo "kill servers"
 # kill servers
-grep -E "WORKER|SERVER" $conf | awk '{print $2;}' | sort | uniq | awk  -v q="'" '
+grep -E "WORKER|SERVER" $conf | awk '{print $2;}' | sort | uniq | awk  -v q="'" -v app="$app" '
 {
-    cmd="ssh immars@" $0 " \"killall caffe\" ";
+    cmd="ssh immars@" $0 " \"killall caffe || killall " app " \" ";
     print cmd;
     system(cmd);
 }

--- a/script/caffe_kill_lan.sh
+++ b/script/caffe_kill_lan.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# set -x
+# export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../third_party/lib
+
+if [ $# -lt 1 ]; then
+    echo "usage: ./caffe_kill_lan.sh conf_path"
+    echo "solver.prototxt resides in subdirectories[S0,S1,...,W0,W1,...] of root_dir"
+    exit -1;
+fi
+
+conf=$1
+tmp=$( mktemp )
+grep -v ^# $conf > $tmp
+conf=$tmp
+
+echo "kill local"
+
+killall caffe
+
+echo "kill servers"
+# kill servers
+grep -E "WORKER|SERVER" $conf | awk '{print $2;}' | sort | uniq | awk  -v q="'" '
+{
+    cmd="ssh immars@" $0 " \"killall caffe\" ";
+    print cmd;
+    system(cmd);
+}
+'

--- a/script/caffe_lan.sh
+++ b/script/caffe_lan.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# set -x
+# export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../third_party/lib
+if [ $# -lt 1 ]; then
+    echo "usage: ./local.sh num_servers num_workers root_dir solver.prototxt [args..]"
+    echo "solver.prototxt resides in subdirectories[S0,S1,...,W0,W1,...] of root_dir"
+    exit -1;
+fi
+
+conf=$1
+bin=$( grep PS_PATH $conf | awk '{print $2;}' )
+sch_ip=$( grep SCHEDULER $conf | awk '{print $2;}' )
+num_servers=$( grep SERVER $conf | wc -l )
+num_workers=$( grep WORKER $conf | wc -l )
+
+arg="-num_servers ${num_servers} -num_workers ${num_workers} $@" #" -app ${dir}/$@"
+
+echo "$bin $conf $sch_ip $num_servers $num_workers"
+killall -q caffe
+
+silence=">/dev/null 2>/dev/null"
+
+
+# start the scheduler
+Sch="role:SCHEDULER,hostname:'$sch_ip',port:8001,id:'H'"
+${bin} -my_node ${Sch} -scheduler ${Sch} ${arg} >/dev/null 2>/dev/null &
+
+# start servers
+grep SERVER $conf | awk -v bin=$bin -v sch=$Sch -v nums=$num_servers -v numw=$num_workers -v q="'" '
+BEGIN{port=9600;id=0;}
+{
+    ip=$2;wd=$3;solver=$4;gpu=$5;snapshot=$6;
+    if(""!=snapshot){
+        snapshot= " --snapshot=" snapshot;
+    }
+    cmd="ssh -f -n immars@" ip " \"source /etc/profile && cd " wd " && nohup " bin " -num_servers " nums " -num_workers " numw " -my_node \\\"role:SERVER,hostname:" q ip q ",port:" port ",id:" q "S" id q "\\\" -scheduler \\\"" sch "\\\" --solver=" solver " --gpu=" gpu " " snapshot " >" wd "/stdout.txt 2>&1 < /dev/null &\" ";
+    print cmd;
+    system(cmd);
+    port=port+1;id=id+1;
+}
+'
+
+grep WORKER $conf | awk -v bin=$bin -v sch=$Sch -v nums=$num_servers -v numw=$num_workers -v q="'" '
+BEGIN{port=9500;id=0;}
+{
+    ip=$2;wd=$3;solver=$4;gpu=$5;
+    cmd="ssh -f -n immars@" ip " \"source /etc/profile && cd " wd " && nohup " bin " -num_servers " nums " -num_workers " numw " -my_node \\\"role:WORKER,hostname:" q ip q ",port:" port ",id:" q "W" id q "\\\" -scheduler \\\"" sch "\\\" --solver=" solver " --pullstep=12 --pushstep=12 --gpu=" gpu " >" wd "/stdout.txt 2>&1 < /dev/null &\" ";
+    print cmd;
+    system(cmd);
+    port=port+1;id=id+1;
+}
+'
+
+
+for ((i=0; i<${num_servers}; ++i)); do
+    port=$((9600 + ${i}))
+    id=S${i}
+    N="role:SERVER,hostname:'127.0.0.1',port:${port},id:'${id}'"
+    # HEAPPROFILE=/tmp/S${i} \
+    # CPUPROFILE=/tmp/S${i} \
+#    cd $root_dir/$id/ && ${bin} -my_node ${N} -scheduler ${Sch} --solver=$solver ${arg} >$root_dir/$id/stdout.txt 2>&1 &
+done
+
+# start workers
+for ((i=0; i<${num_workers}; ++i)); do
+    port=$((9500 + ${i}))
+    id=W${i}
+    N="role:WORKER,hostname:'127.0.0.1',port:${port},id:'${id}'"
+    # HEAPPROFILE=/tmp/W${i} \
+    # CPUPROFILE=/tmp/W${i} \
+#    cd $root_dir/$id/ && ${bin} -my_node ${N} -scheduler ${Sch} --solver=$solver ${arg} >$root_dir/$id/stdout.txt 2>&1 &
+done
+

--- a/script/caffe_lan.sh
+++ b/script/caffe_lan.sh
@@ -8,10 +8,16 @@ if [ $# -lt 1 ]; then
 fi
 
 conf=$1
+tmp=$( mktemp )
+grep -v ^# $conf > $tmp
+conf=$tmp
+
 bin=$( grep PS_PATH $conf | awk '{print $2;}' )
 sch_ip=$( grep SCHEDULER $conf | awk '{print $2;}' )
 num_servers=$( grep SERVER $conf | wc -l )
 num_workers=$( grep WORKER $conf | wc -l )
+pullstep=$( grep PULL $conf | awk '{print $2;}' )
+pushstep=$( grep PUSH $conf | awk '{print $2;}' )
 
 arg="-num_servers ${num_servers} -num_workers ${num_workers} $@" #" -app ${dir}/$@"
 
@@ -26,25 +32,25 @@ Sch="role:SCHEDULER,hostname:'$sch_ip',port:8001,id:'H'"
 ${bin} -my_node ${Sch} -scheduler ${Sch} ${arg} >/dev/null 2>/dev/null &
 
 # start servers
-grep SERVER $conf | awk -v bin=$bin -v sch=$Sch -v nums=$num_servers -v numw=$num_workers -v q="'" '
+grep SERVER $conf | awk -v bin=$bin -v sch=$Sch -v nums=$num_servers -v numw=$num_workers -vpullstep=$pullstep -vpushstep=$pushstep -v q="'" '
 BEGIN{port=9600;id=0;}
 {
     ip=$2;wd=$3;solver=$4;gpu=$5;snapshot=$6;
     if(""!=snapshot){
         snapshot= " --snapshot=" snapshot;
     }
-    cmd="ssh -f -n immars@" ip " \"source /etc/profile && cd " wd " && nohup " bin " -num_servers " nums " -num_workers " numw " -my_node \\\"role:SERVER,hostname:" q ip q ",port:" port ",id:" q "S" id q "\\\" -scheduler \\\"" sch "\\\" --solver=" solver " --gpu=" gpu " " snapshot " >" wd "/stdout.txt 2>&1 < /dev/null &\" ";
+    cmd="ssh -f -n immars@" ip " \"source /etc/profile && cd " wd " && nohup " bin " -num_servers " nums " -num_workers " numw " -my_node \\\"role:SERVER,hostname:" q ip q ",port:" port ",id:" q "S" id q "\\\" -scheduler \\\"" sch "\\\" --solver=" solver " --pullstep=" pullstep " --pushstep=" pushstep " --gpu=" gpu " " snapshot " >" wd "/stdout.txt 2>&1 < /dev/null &\" ";
     print cmd;
     system(cmd);
     port=port+1;id=id+1;
 }
 '
 
-grep WORKER $conf | awk -v bin=$bin -v sch=$Sch -v nums=$num_servers -v numw=$num_workers -v q="'" '
+grep WORKER $conf | awk -v bin=$bin -v sch=$Sch -v nums=$num_servers -v numw=$num_workers -vpullstep=$pullstep -vpushstep=$pushstep -v q="'" '
 BEGIN{port=9500;id=0;}
 {
     ip=$2;wd=$3;solver=$4;gpu=$5;
-    cmd="ssh -f -n immars@" ip " \"source /etc/profile && cd " wd " && nohup " bin " -num_servers " nums " -num_workers " numw " -my_node \\\"role:WORKER,hostname:" q ip q ",port:" port ",id:" q "W" id q "\\\" -scheduler \\\"" sch "\\\" --solver=" solver " --pullstep=12 --pushstep=12 --gpu=" gpu " >" wd "/stdout.txt 2>&1 < /dev/null &\" ";
+    cmd="ssh -f -n immars@" ip " \"source /etc/profile && cd " wd " && nohup " bin " -num_servers " nums " -num_workers " numw " -my_node \\\"role:WORKER,hostname:" q ip q ",port:" port ",id:" q "W" id q "\\\" -scheduler \\\"" sch "\\\" --solver=" solver " --pullstep=" pullstep " --pushstep=" pushstep " --gpu=" gpu " >" wd "/stdout.txt 2>&1 < /dev/null &\" ";
     print cmd;
     system(cmd);
     port=port+1;id=id+1;

--- a/script/caffe_lan.sh
+++ b/script/caffe_lan.sh
@@ -49,31 +49,14 @@ BEGIN{port=9600;id=0;}
 grep WORKER $conf | awk -v bin=$bin -v sch=$Sch -v nums=$num_servers -v numw=$num_workers -vpullstep=$pullstep -vpushstep=$pushstep -v q="'" '
 BEGIN{port=9500;id=0;}
 {
-    ip=$2;wd=$3;solver=$4;gpu=$5;
-    cmd="ssh -f -n immars@" ip " \"source /etc/profile && cd " wd " && nohup " bin " -num_servers " nums " -num_workers " numw " -my_node \\\"role:WORKER,hostname:" q ip q ",port:" port ",id:" q "W" id q "\\\" -scheduler \\\"" sch "\\\" --solver=" solver " --pullstep=" pullstep " --pushstep=" pushstep " --gpu=" gpu " >" wd "/stdout.txt 2>&1 < /dev/null &\" ";
+    ip=$2;wd=$3;solver=$4;gpu=$5;workers=$6;
+    if(""!=workers){
+        workers = " --workers=" workers;
+    }
+    cmd="ssh -f -n immars@" ip " \"source /etc/profile && cd " wd " && nohup " bin " -num_servers " nums " -num_workers " numw " -my_node \\\"role:WORKER,hostname:" q ip q ",port:" port ",id:" q "W" id q "\\\" -scheduler \\\"" sch "\\\" --solver=" solver " --pullstep=" pullstep " --pushstep=" pushstep " --synced=true --gpu=" gpu " " workers " >" wd "/stdout.txt 2>&1 < /dev/null &\" ";
     print cmd;
     system(cmd);
     port=port+1;id=id+1;
 }
 '
-
-
-for ((i=0; i<${num_servers}; ++i)); do
-    port=$((9600 + ${i}))
-    id=S${i}
-    N="role:SERVER,hostname:'127.0.0.1',port:${port},id:'${id}'"
-    # HEAPPROFILE=/tmp/S${i} \
-    # CPUPROFILE=/tmp/S${i} \
-#    cd $root_dir/$id/ && ${bin} -my_node ${N} -scheduler ${Sch} --solver=$solver ${arg} >$root_dir/$id/stdout.txt 2>&1 &
-done
-
-# start workers
-for ((i=0; i<${num_workers}; ++i)); do
-    port=$((9500 + ${i}))
-    id=W${i}
-    N="role:WORKER,hostname:'127.0.0.1',port:${port},id:'${id}'"
-    # HEAPPROFILE=/tmp/W${i} \
-    # CPUPROFILE=/tmp/W${i} \
-#    cd $root_dir/$id/ && ${bin} -my_node ${N} -scheduler ${Sch} --solver=$solver ${arg} >$root_dir/$id/stdout.txt 2>&1 &
-done
 

--- a/script/caffe_local.sh
+++ b/script/caffe_local.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# set -x
+# export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../third_party/lib
+if [ $# -lt 3 ]; then
+    echo "usage: ./local.sh num_servers num_workers root_dir solver.prototxt [args..]"
+    echo "solver.prototxt resides in subdirectories[S0,S1,...,W0,W1,...] of root_dir"
+    exit -1;
+fi
+
+bin=$(pwd)/build/caffe
+num_servers=$1
+shift
+num_workers=$1
+shift
+root_dir=$1
+shift
+solver=$1
+shift
+arg="-num_servers ${num_servers} -num_workers ${num_workers} $@" #" -app ${dir}/$@"
+
+
+# killall -q $(basename ${bin})
+killall -q ${bin}
+sleep 1
+
+silence=">/dev/null 2>/dev/null"
+
+
+# start the scheduler
+Sch="role:SCHEDULER,hostname:'127.0.0.1',port:8001,id:'H'"
+${bin} -my_node ${Sch} -scheduler ${Sch} ${arg} >/dev/null 2>/dev/null &
+
+# start servers
+for ((i=0; i<${num_servers}; ++i)); do
+    port=$((9600 + ${i}))
+    id=S${i}
+    N="role:SERVER,hostname:'127.0.0.1',port:${port},id:'${id}'"
+    # HEAPPROFILE=/tmp/S${i} \
+    # CPUPROFILE=/tmp/S${i} \
+    cd $root_dir/$id/ && ${bin} -my_node ${N} -scheduler ${Sch} --solver=$solver ${arg} >$root_dir/$id/stdout.txt 2>&1 &
+done
+
+# start workers
+for ((i=0; i<${num_workers}; ++i)); do
+    port=$((9500 + ${i}))
+    id=W${i}
+    N="role:WORKER,hostname:'127.0.0.1',port:${port},id:'${id}'"
+    # HEAPPROFILE=/tmp/W${i} \
+    # CPUPROFILE=/tmp/W${i} \
+    cd $root_dir/$id/ && ${bin} -my_node ${N} -scheduler ${Sch} --solver=$solver ${arg} >$root_dir/$id/stdout.txt 2>&1 &
+done
+
+wait

--- a/script/caffe_local.sh
+++ b/script/caffe_local.sh
@@ -7,7 +7,7 @@ if [ $# -lt 3 ]; then
     exit -1;
 fi
 
-bin=$( pwd -L )/build/caffe
+bin=$( pwd -L )/build/caffe_sync
 num_servers=$1
 shift
 num_workers=$1
@@ -38,7 +38,7 @@ for ((i=0; i<${num_servers}; ++i)); do
     # HEAPPROFILE=/tmp/S${i} \
     # CPUPROFILE=/tmp/S${i} \
     echo "cd $root_dir/$id/ && ${bin} -my_node ${N} -scheduler ${Sch} --solver=$solver ${arg} >$root_dir/$id/stdout.txt 2>&1 &"
-    cd $root_dir/$id/ && ${bin} -my_node ${N} -scheduler ${Sch} --solver=$solver ${arg} >$root_dir/$id/stdout.txt 2>&1 &
+    cd $root_dir/$id/ && ${bin} -my_node ${N} -scheduler ${Sch} --pullstep=2 --pushstep=2 --solver=$solver ${arg} >$root_dir/$id/stdout.txt 2>&1 &
 done
 
 # start workers

--- a/script/caffe_local.sh
+++ b/script/caffe_local.sh
@@ -7,7 +7,7 @@ if [ $# -lt 3 ]; then
     exit -1;
 fi
 
-bin=$(pwd)/build/caffe
+bin=$( pwd -L )/build/caffe
 num_servers=$1
 shift
 num_workers=$1
@@ -37,6 +37,7 @@ for ((i=0; i<${num_servers}; ++i)); do
     N="role:SERVER,hostname:'127.0.0.1',port:${port},id:'${id}'"
     # HEAPPROFILE=/tmp/S${i} \
     # CPUPROFILE=/tmp/S${i} \
+    echo "cd $root_dir/$id/ && ${bin} -my_node ${N} -scheduler ${Sch} --solver=$solver ${arg} >$root_dir/$id/stdout.txt 2>&1 &"
     cd $root_dir/$id/ && ${bin} -my_node ${N} -scheduler ${Sch} --solver=$solver ${arg} >$root_dir/$id/stdout.txt 2>&1 &
 done
 

--- a/script/caffe_local.sh
+++ b/script/caffe_local.sh
@@ -28,7 +28,7 @@ silence=">/dev/null 2>/dev/null"
 
 # start the scheduler
 Sch="role:SCHEDULER,hostname:'127.0.0.1',port:8001,id:'H'"
-${bin} -my_node ${Sch} -scheduler ${Sch} ${arg} >/dev/null 2>/dev/null &
+${bin} -my_node ${Sch} -scheduler ${Sch} ${arg}  &
 
 # start servers
 for ((i=0; i<${num_servers}; ++i)); do
@@ -48,7 +48,7 @@ for ((i=0; i<${num_workers}; ++i)); do
     N="role:WORKER,hostname:'127.0.0.1',port:${port},id:'${id}'"
     # HEAPPROFILE=/tmp/W${i} \
     # CPUPROFILE=/tmp/W${i} \
-    cd $root_dir/$id/ && ${bin} -my_node ${N} -scheduler ${Sch} --solver=$solver ${arg} >$root_dir/$id/stdout.txt 2>&1 &
+    cd $root_dir/$id/ && ${bin} -my_node ${N} -scheduler ${Sch} --pullstep=2 --pushstep=2 --solver=$solver ${arg} >$root_dir/$id/stdout.txt 2>&1 &
 done
 
 wait

--- a/src/app/caffe/caffe_async_share.cc
+++ b/src/app/caffe/caffe_async_share.cc
@@ -502,12 +502,13 @@ public:
       t5 = tick(&tv);
       // bypass all of computeUpdateValue
       solver->stepEnd();
+      /*
       LL << "# " << id << "\ttryCopyWeight\t"<< (t1-t0)
               << "\ttestPhase\t"<< (t2-t1)
               << "\tforwardBackward\t"<< (t3-t2)
               << "\taccumulateDiff\t"<< (t4-t3)
               << "\tdisplayPhase\t"<< (t5-t4);
-
+      */
     }
     LL << "Forwarder sending forward end signal";
     signalForwardEnd();

--- a/src/app/caffe/caffe_async_share.cc
+++ b/src/app/caffe/caffe_async_share.cc
@@ -651,7 +651,16 @@ public:
       ostringstream name;
       name << "gatherDiff:solver.blobs[" << i << "]";
 //      checkNAN(blob->count(), blob->cpu_diff(), name.str());
-      caffe::caffe_add(acc->count(), blob->cpu_diff(), acc->cpu_diff(), acc->mutable_cpu_diff());
+      switch (Caffe::mode()) {
+        case Caffe::CPU:
+          caffe::caffe_add(acc->count(), blob->cpu_diff(), acc->cpu_diff(), acc->mutable_cpu_diff());
+          break;
+        case Caffe::GPU:
+          caffe::caffe_gpu_add(acc->count(), blob->gpu_diff(), acc->gpu_diff(), acc->mutable_gpu_diff());
+          break;
+        default:
+          LOG(FATAL) << "Unknown caffe mode: " << Caffe::mode();
+      }
     }
     diffCount++;
     if(diffCount >= FLAGS_pushstep) {

--- a/src/app/caffe/caffe_async_share.cc
+++ b/src/app/caffe/caffe_async_share.cc
@@ -1,0 +1,743 @@
+#include <iostream>
+#include <unistd.h>
+#include <chrono>
+#include <thread>
+#include <google/protobuf/io/coded_stream.h>
+
+#include "ps.h"
+#include "system/app.h"
+#include "parameter/v_vector.h"
+#include "parameter/kv_vector.h"
+#include "caffe/caffe.hpp"
+#include "caffe/common.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/util/upgrade_proto.hpp"
+#include "app/caffe/util.h"
+
+using namespace caffe;
+using namespace std;
+using caffe::Blob;
+using caffe::Solver;
+using caffe::SolverParameter;
+using caffe::Caffe;
+using caffe::caffe_scal;
+using google::protobuf::io::CodedInputStream;
+using std::string;
+using std::vector;
+
+// caffe cmd flags
+
+DEFINE_int32(gpu, -1,
+    "Run in GPU mode on given device ID.");
+DEFINE_string(solver, "",
+    "The solver definition protocol buffer text file.");
+DEFINE_string(model, "",
+    "The model definition protocol buffer text file..");
+DEFINE_string(snapshot, "",
+    "Optional; the snapshot solver state to resume training.");
+DEFINE_string(workers, "W0",
+    "cwd if workers, subdirectory of current directory.");
+DEFINE_bool(fb_only, true,
+    "DEPRECATED; workers only ForwardBackward.");
+DEFINE_bool(synced, false,
+    "DEPRECATED; pull/push synced with Forward");
+// client puller / pusher flags
+DEFINE_int32(pushstep, 3,
+    "interval, in minibatches, between push operation.");
+DEFINE_int32(pullstep, 3,
+    "DEPRECATED interval, in minibatches, between pull operation.");
+
+caffe::SolverParameter solver_param;
+Solver<float>* initCaffeSolver(int id){
+
+  Solver<float>* solver;
+
+  CHECK_GT(FLAGS_solver.size(), 0) << "Need a solver definition to train.";
+
+  caffe::ReadProtoFromTextFileOrDie(FLAGS_solver, &solver_param);
+
+  if (id < 0) {
+    id = FLAGS_gpu;
+  }
+
+  if (id < 0
+      && solver_param.solver_mode() == caffe::SolverParameter_SolverMode_GPU) {
+    id = solver_param.device_id();
+  }
+
+  // Set device id and mode
+  if (id >= 0) {
+    LOG(INFO) << "Use GPU with device ID " << id;
+    Caffe::SetDevice(id);
+    Caffe::set_mode(Caffe::GPU);
+  } else {
+    LOG(INFO) << "Use CPU.";
+    Caffe::set_mode(Caffe::CPU);
+  }
+
+  solver = caffe::GetSolver<float>(solver_param);
+
+  if (FLAGS_snapshot.size()) {
+    LOG(INFO) << "Resuming from " << FLAGS_snapshot;
+    solver->Restore(FLAGS_snapshot.c_str());
+  }
+
+  return solver;
+}
+
+caffe::Net<float>* initCaffeNet(){
+  CHECK_GT(FLAGS_solver.size(), 0) << "Need a solver definition to train.";
+
+  caffe::ReadProtoFromTextFileOrDie(FLAGS_solver, &solver_param);
+
+  caffe::NetParameter net_param;
+  std::string net_path = solver_param.net();
+  caffe::ReadNetParamsFromTextFileOrDie(net_path, &net_param);
+  return new caffe::Net<float>(net_param);
+}
+
+#define V_WEIGHT "weight"
+#define V_DIFF "diff"
+#define V_SOLVER "solver"
+namespace PS {
+
+static std::mutex mu_pwd;
+Solver<float>* initCaffeSolverInDir(int id, string root){
+  Lock l(mu_pwd);
+  char* cwd = getcwd(nullptr,1024);
+  LL << "cwd: " << cwd;
+  CHECK(cwd != nullptr);
+  CHECK(0 == chdir(root.c_str()));
+  Solver<float>* solver = initCaffeSolver(id);
+  CHECK(0 == chdir(cwd));
+  free(cwd);
+  return solver;
+}
+
+
+class CaffeServer : public App, public VVListener<float>, public VVListener<char> {
+ public:
+  CaffeServer(const string& name, const string& conf) : App(name) { }
+  virtual ~CaffeServer() { }
+
+  virtual void init() {
+    LL << myNodeID() << ", this is server " << myRank();
+
+    solver = initCaffeSolver(-1);
+
+    // initialize the weight at server
+    int total_weight = 0;
+    weights = new VVector<float>(V_WEIGHT, true, this);
+    diffs = new VVector<float>(V_DIFF, false, this);
+    solver_states = new VVector<char>(V_SOLVER, true, this);
+
+    for (int i = 0; i < solver->net()->params().size();i++){
+      auto blob = solver->net()->params()[i];
+      weights->value(i).reset(blob->mutable_cpu_data(), blob->count(), false);
+      Blob<float>* newBlob = new Blob<float>(blob->num(), blob->channels(), blob->height(), blob->width());
+      diffBlobs.push_back(newBlob);
+      diffs->value(i).reset(newBlob->mutable_cpu_diff(), newBlob->count(), false);
+      total_weight += blob->data()->size();
+    }
+
+    LL << "total weight size:" << total_weight;
+  }
+  
+  void testPhase(){
+    Lock l(mu_solver);
+    solver->TestAll();
+  }
+
+  void snapshotPhase(){
+    Lock l(mu_solver);
+    solver->Snapshot();
+  }
+
+  void run() {
+    LL << myNodeID() << ", server " << myRank() << " run()ing";
+
+  }
+
+  void process(const MessagePtr& msg) {
+    auto sgd = msg->task.sgd();
+    if (sgd.cmd() == SGDCall::UPDATE_MODEL) { // sync param to memory
+    {
+      Lock l(mu_solver);
+    }
+    }
+  }
+
+  void vectorChanged(VVector<float>* data){
+//    LL << "vector change received:" << data->name();
+    CHECK_EQ(data, this->diffs) << "server only accept diff changes";
+
+    Lock l(mu_solver);
+//    float first,last, firstv, lastv;
+    for (int i = 0; i < solver->net()->params().size();i++){
+      auto blob = solver->net()->params()[i];
+      float* dest = blob->mutable_cpu_diff();
+      auto src = diffs->value(i);
+      memcpy(dest, src.data(), blob->diff()->size());
+
+      //scale down?
+      if(FLAGS_pushstep != 0){
+        caffe::caffe_scal(blob->count(), float(1.0 / FLAGS_pushstep), dest);
+      }
+/*      if(i==0){
+    first=blob->cpu_diff()[0];
+    firstv = src[0];
+      }else if(i == solver->net()->params().size()-1){
+    last=blob->cpu_diff()[blob->count()-1];
+    lastv = src[src.size() - 1];
+      }
+*/
+    }
+
+//    LL<< "got diff[" << first<<",...,"<<last<<"]/[" << firstv << ",...," << lastv <<"]";
+
+    solver->ComputeUpdateValue();
+    solver->net()->Update();
+    solver->snapshotPhase();
+    solver->stepEnd();
+
+ }
+  void vectorChanged(VVector<char>* data){
+    CHECK(false) << "shouldn't be any VVector<char> change: "<< data->name();
+  }
+
+  void vectorGetting(VVector<float>* data){
+    Lock l(mu_solver);
+    float first, last;
+    if (data == this->weights){
+      // need to sync to CPU
+      for (int i = 0; i < solver->net()->params().size();i++){
+        auto blob = solver->net()->params()[i];
+        blob->cpu_data();
+        if (i==0) {
+          first = blob->cpu_data()[0];
+        } else if (i == solver->net()->params().size() - 1 ) {
+          last = blob->cpu_data()[blob->count()-1];
+        }
+      }
+      LL << "weight synced: ["<<first<<","<<last<<"]";
+    } else {
+      CHECK(false) << "some one is getting none-gettable! " << data->name();
+    }
+  }
+
+  void vectorGetting(VVector<char>* data){
+    LL << "getting char: "<< data->name();
+    Lock l(mu_solver);
+    if (data == this->solver_states){
+      // need to serialize solver state into solver_states
+      caffe::SolverState state;
+      this->solver->SnapshotSolverState(&state);
+      state.set_iter(solver->iter());
+      state.set_current_step(solver->current_step());
+      string buf;
+      state.SerializeToString(&buf);
+      solver_states->value(0).resize( buf.size() );
+      memcpy(solver_states->value(0).data(), buf.data(), buf.size());
+      LL << "server solver state saved, history:" << state.history_size() << ", total:" << buf.size();
+    } else {
+      CHECK(false) << "some one is getting none-gettable! " << data->name();
+    }
+  }
+
+
+ private:
+  VVector<char> *solver_states; // individual data ptr, solver state to initialize workers
+  VVector<float> *weights; //share data ptr with solver->net->params->cpu_data
+  VVector<float> *diffs; //individual data ptr with diffBlobs
+  std::vector<Blob<float>*> diffBlobs;
+
+  std::mutex mu_solver;
+  caffe::Solver<float>* solver;
+};
+
+App* CreateServerNode(const std::string& conf) {
+  return new CaffeServer("app", conf);
+}
+
+
+class CaffeWorker;
+
+class NetForwarder {
+
+  bool terminated;
+  int id;
+  CaffeWorker* worker;
+  string rootDir;
+  caffe::Solver<float>* solver;
+  int weightVersion; // current version
+  int wantedVersion; // wanted version; increase with iterations
+  std::mutex mu_forward;
+  std::condition_variable cv_forward;
+  bool start_forward;
+  std::unique_ptr<std::thread> internalThread;
+
+  bool needDisplay;
+
+public:
+  NetForwarder(CaffeWorker* parent, int id, string workerRoot, bool display):
+    id(id),worker(parent),rootDir(workerRoot),
+    solver(nullptr),weightVersion(0),start_forward(false),needDisplay(display){
+  }
+
+  /**
+   * by CaffeForwarder
+   */
+  void waitForwardSignal(){
+    std::unique_lock<std::mutex> l(mu_forward);
+    while(!start_forward){
+      cv_forward.wait(l);
+    }
+  }
+
+  /**
+   * by CaffeForwarder
+   */
+  void signalForwardEnd(){
+    std::unique_lock<std::mutex> l(mu_forward);
+    start_forward = false;
+    cv_forward.notify_all();
+  }
+
+  /**
+   * by CaffeWorker
+   */
+  void signalForward() {
+    std::unique_lock<std::mutex> l(mu_forward);
+    start_forward = true;
+    cv_forward.notify_all();
+  }
+
+  /**
+   * by CaffeWorker
+   */
+  void joinForwardEnd() {
+    if(!start_forward){
+      return;
+    }
+    {
+      std::unique_lock<std::mutex> l(mu_forward);
+      while(start_forward) {
+        cv_forward.wait(l);
+      }
+    }
+  }
+
+  void copyWeight();
+
+  void tryCopyWeight();
+
+  void accumulateDiff();
+
+  void start() {
+    if(nullptr == solver) {
+      solver = initCaffeSolverInDir(id, rootDir);
+      LL << "Inited solver On device id # " << id;
+    }
+    /*
+    if (this->id >= 0) {
+      LOG(INFO) << "Net Use GPU with device ID " << this->id;
+      Caffe::SetDevice(this->id);
+      Caffe::set_mode(Caffe::GPU);
+    } else {
+      LOG(INFO) << "Use CPU.";
+      Caffe::set_mode(Caffe::CPU);
+    }
+    */
+//    this->net = initCaffeNet();
+    int iter = solver->param().max_iter() - solver->iter();
+    LL << "start training loop # " << id;
+    waitForwardSignal();
+    LL << "start() forward signal received";
+    copyWeight();
+    for (int i = 0; i < iter; i++) {
+      tryCopyWeight();
+      // wait signal to forward
+      if(needDisplay){
+        solver->testPhase();
+      }
+      LL<< "forwarder # " << id;
+      solver->forwardBackwardPhase();
+      this->accumulateDiff();
+      if(needDisplay){
+        solver->displayPhase();
+      }
+      // bypass all of computeUpdateValue
+      solver->stepEnd();
+      LL << "pushstep " << FLAGS_pushstep << " reached.";
+      LL << "Forwarder sending forward end signal";
+    }
+    signalForwardEnd();
+  }
+
+  void startAsync(){
+    if(!internalThread.get()){
+      internalThread.reset(new thread(&NetForwarder::start, this));
+    }
+  }
+
+  void stop() {
+    //TODO
+  }
+};
+
+std::vector<std::string> &split(const std::string &s, char delim, std::vector<std::string> &elems) {
+    std::stringstream ss(s);
+    std::string item;
+    while (std::getline(ss, item, delim)) {
+        elems.push_back(item);
+    }
+    return elems;
+}
+
+
+std::vector<std::string> split(const std::string &s, char delim) {
+    std::vector<std::string> elems;
+    split(s, delim, elems);
+    return elems;
+}
+
+class CaffeWorker: public App{
+private:
+
+  std::mutex mu_weight; // protect write to weight_ready and weights
+  std::mutex mu_diff;  //protect write to diffs
+
+
+  std::mutex mu_forward;
+  std::condition_variable cv_forward;
+  bool start_forward;
+
+  std::mutex mu_push;
+  std::condition_variable cv_push;
+  std::mutex mu_pull;
+  std::condition_variable cv_pull;
+
+  int weightVersion; // current version no. of weights, in iteration count
+  int requestedVersion; // wanted version no. of weights, in iteration count
+  VVector<float> *weights;// individual data ptr, same order/size as solver->net->params
+  VVector<float> *diffs;// for accumulated diff, share memory with diffBlobs
+  int diffCount; // accumulated diff count
+  std::vector<Blob<float>*> diffBlobs;
+  caffe::Solver<float>* solver;
+
+  std::unique_ptr<std::thread> pusher;
+  std::unique_ptr<std::thread> puller;
+
+  volatile bool _terminate = false;
+
+  std::vector<NetForwarder*> forwarders;
+
+public:
+  CaffeWorker(const string& name, const string& conf):App(name){
+    weightVersion = 0;
+    requestedVersion = 0;
+  }
+  ~CaffeWorker(){
+
+  }
+
+  void init(){
+    LL << "worker init()";
+    start_forward = false;
+    solver = initCaffeSolver(-1);
+    //init shared parameter at worker
+    weights = new VVector<float>(V_WEIGHT);
+    diffs = new VVector<float>(V_DIFF);
+
+    for (int i = 0; i < solver->net()->params().size();i++){
+      auto blob = solver->net()->params()[i];
+      weights->value(i).resize(blob->count());
+      Blob<float>* newBlob = new Blob<float>(blob->num(), blob->channels(), blob->height(), blob->width());
+      diffBlobs.push_back(newBlob);
+      diffs->value(i).reset(newBlob->mutable_cpu_diff(), newBlob->count(), false);
+    }
+
+    //init pusher/puller
+    pusher.reset(new std::thread(&CaffeWorker::pusherMain, this));
+    puller.reset(new std::thread(&CaffeWorker::pullerMain, this));
+
+    //init forwarders
+    vector<string> workerRoots = split(FLAGS_workers, ',');
+    char* cwd = getcwd(nullptr,1024);
+    LL << "cwd: " << cwd;
+    CHECK(cwd != nullptr);
+    string cwdString(cwd);
+    for (int id = 0; id < workerRoots.size(); id++){
+      bool display = id == 0;
+      string workerRoot = cwdString + "/" + workerRoots[id];
+      LL << "creating forwarder in: " << workerRoot;
+//      CHECK(0 == chdir(workerRoot.c_str()));
+      NetForwarder* forwarder = new NetForwarder(this, id, workerRoot, display);
+      forwarders.push_back(forwarder);
+      forwarder->startAsync();
+    }
+//    CHECK(0 == chdir(cwd));
+    free(cwd);
+    LL << "worker init() over";
+  }
+
+  /**
+   * by run() thread
+   */
+  void waitForwardSignal(){
+    std::unique_lock<std::mutex> l(mu_forward);
+    while(!start_forward){
+      cv_forward.wait(l);
+    }
+  }
+
+  /**
+   * by run() thread
+   */
+  void signalForwardEnd(){
+    std::unique_lock<std::mutex> l(mu_forward);
+    start_forward = false;
+    cv_forward.notify_all();
+  }
+
+  /**
+   * by process() thread
+   */
+  void signalAndJoinForward() {
+    std::unique_lock<std::mutex> l(mu_forward);
+    start_forward = true;
+    cv_forward.notify_all();
+    while(start_forward) {
+      cv_forward.wait(l);
+    }
+  }
+
+  void pullerMain(){
+    LL << "puller start";
+    while(true){
+      waitPullSignal();
+      pullWeight();
+    }
+    LL << "puller exit";
+  }
+
+  void pusherMain(){
+    LL << "pusher start";
+    while(true){
+      waitPushSignal();
+      pushDiff();
+    }
+    LL << "pusher exit";
+  }
+
+  /**
+   * by pusher thread
+   */
+  void waitPushSignal(){
+    std::unique_lock<std::mutex> l(mu_push);
+    cv_push.wait(l);
+  }
+
+  void signalPush(){
+    std::unique_lock<std::mutex> l(mu_push);
+    cv_push.notify_all();
+  }
+
+  /**
+   * by puller thread
+   */
+  void waitPullSignal(){
+    std::unique_lock<std::mutex> l(mu_pull);
+    cv_pull.wait(l);
+  }
+
+  void signalPull(){
+    std::unique_lock<std::mutex> l(mu_pull);
+    cv_pull.notify_all();
+  }
+
+
+
+  /**
+   * by main
+   */
+  void run(){
+    LL << "worker run()";
+    LL << "worker run() over";
+  }
+
+  void process(const MessagePtr& msg) {
+    LL << "message received";
+    auto sgd = msg->task.sgd();
+    if (sgd.cmd() == SGDCall::UPDATE_MODEL) { // sync param to memory
+      LL << "process() update model received";
+      signalAndJoinForward();
+      LL << "process() forward end received";
+    }
+  }
+
+  /**
+   * by forwarder
+   */
+  void gatherDiff(Solver<float>* another) {
+    Lock l(mu_diff);
+    for(int i = 0; i < another->net()->params().size(); i++){
+      auto acc = diffBlobs[i];
+      auto blob = another->net()->params()[i];
+      ostringstream name;
+      name << "gatherDiff:solver.blobs[" << i << "]";
+//      checkNAN(blob->count(), blob->cpu_diff(), name.str());
+      caffe::caffe_add(acc->count(), blob->cpu_diff(), acc->cpu_diff(), acc->mutable_cpu_diff());
+    }
+    diffCount++;
+    if(diffCount >= FLAGS_pushstep) {
+      signalPush();
+    }
+  }
+
+  /**
+   * by pusher, synchronized (block until message sent)
+   */
+  void pushDiff(){
+    Lock l(mu_diff);
+    //push to app instead of
+    MessagePtr msg(new Message(kServerGroup));
+    msg->key = {0};
+    msg->task.set_key_channel(0);
+    float first, last;
+    for(int i = 0; i < diffs->vcount();i++){
+      auto acc = diffBlobs[i];
+      acc->cpu_diff(); // sync to cpu
+      auto diff = diffs->value(i);
+      CHECK_EQ(acc->cpu_diff(), diff.data());
+      msg->addValue(diff);
+      if(i == 0){
+        first = acc->cpu_diff()[0];
+      }else if(i == diffs->vcount() - 1){
+        last = acc->cpu_diff()[acc->count()-1];
+      }
+    }
+    int push_time = diffs->push(msg);
+    diffs->waitOutMsg(kServerGroup, push_time);
+    LL << "Worker diff("<< diffCount <<") pushed:[" << first <<"," << last << "]";
+    //clear previous diff
+    for(auto acc : diffBlobs){
+      memset(acc->mutable_cpu_diff(), 0, acc->diff()->size());
+    }
+    // clear diff count
+    diffCount = 0;
+  }
+
+  /**
+   * by puller (except the initial pull), synchronized
+   */
+  void pullWeight(){
+    LL << "begin pull weight";
+//    Task task;
+//    task.mutable_sgd()->set_cmd(SGDCall::UPDATE_MODEL);
+//    port(kServerGroup)->submitAndWait(task);
+
+    Lock l(mu_weight);
+    MessagePtr msg(new Message(kServerGroup));
+    msg->key = {0};
+    LL << "begin pull";
+    int pull_time = weights->pull(msg);
+    LL << "begin waitOutMsg";
+    weights->waitOutMsg(kServerGroup, pull_time);
+    this->weightVersion = this->requestedVersion;
+    LL << "weight pulled from server, total:" << weights->totalSize();
+  }
+
+  /**
+   * by forwarder
+   */
+  void copyWeight(Solver<float>* another, int* version){
+    float first,last;
+    for (int i = 0; i < another->net()->params().size();i++){
+      auto blob = another->net()->params()[i];
+      float* dest = blob->mutable_cpu_data();
+      auto src = weights->value(i);
+      memcpy(dest, src.data(), blob->data()->size());
+      //TODO direct copy to GPU?
+      if(i == 0){
+        first = blob->cpu_data()[0];
+      }else if(i == another->net()->params().size()-1){
+        last = blob->cpu_data()[blob->count()-1];
+      }
+    }
+    *version = weightVersion;
+    LL << "weight from server:[" << first << ",...," << last << "]";
+  }
+
+  /**
+   * by forwarder, check weight version & current wanted newest version number against worker's weight;
+   * copy if newer version arrived;
+   * mark
+   */
+  bool tryCopyWeight(Solver<float>* another, int* anotherCurrentVersion, int anotherWantedVersion){
+    if(requestedVersion < anotherWantedVersion){
+      Lock l(mu_weight);
+      if(requestedVersion < anotherWantedVersion){
+        requestedVersion = anotherWantedVersion;
+        if(requestedVersion - weightVersion >= FLAGS_pullstep){
+          signalPull();
+        }
+      }
+    }
+    if(weightVersion < *anotherCurrentVersion){
+      // no need to copy; mark newer verion requested
+      Lock l(mu_weight);
+      //double check
+      if(weightVersion < *anotherCurrentVersion){
+        return false;
+      }
+    }
+    // need to copy
+    copyWeight(another, anotherCurrentVersion);
+    return true;
+  }
+};
+void NetForwarder::copyWeight() {
+  this->worker->copyWeight(this->solver, &this->weightVersion);
+}
+
+
+void NetForwarder::tryCopyWeight() {
+  if(this->worker->tryCopyWeight(this->solver, &this->weightVersion, this->wantedVersion)){
+    // copy successful; reset version counter to this newly copied version
+    this->wantedVersion = this->weightVersion;
+  }
+  this->wantedVersion ++;
+}
+
+void NetForwarder::accumulateDiff(){
+  this->worker->gatherDiff(this->solver);
+}
+
+} // namespace PS
+
+namespace PS {
+App* App::create(const string& name, const string& conf) {
+  auto my_role = Postoffice::instance().myNode().role();
+  if (my_role == Node::SERVER) {
+    return new CaffeServer(name, conf);
+  } else if(my_role == Node::WORKER){
+      return new CaffeWorker(name, conf);
+  }else{
+    return new App();
+  }
+}
+} // namespace PS
+
+
+int main(int argc, char *argv[]) {
+
+  google::ParseCommandLineFlags(&argc, &argv, true);
+
+  auto& sys = PS::Postoffice::instance();
+  sys.start(&argc, &argv);
+
+  sys.stop();
+  return 0;
+}
+

--- a/src/app/caffe/caffe_async_share.cc
+++ b/src/app/caffe/caffe_async_share.cc
@@ -504,7 +504,7 @@ public:
       t5 = tick(&tv);
       // bypass all of computeUpdateValue
       solver->stepEnd();
-      LL << "tryCopyWeight\t"<< (t1-t0)
+      LL << "# " << id << "\ttryCopyWeight\t"<< (t1-t0)
               << "\ttestPhase\t"<< (t2-t1)
               << "\tforwardBackward\t"<< (t3-t2)
               << "\taccumulateDiff\t"<< (t4-t3)

--- a/src/app/caffe/caffe_async_share.cc
+++ b/src/app/caffe/caffe_async_share.cc
@@ -467,11 +467,6 @@ public:
 
   void accumulateDiff();
 
-  inline unsigned long long tick(struct timeval* tv) {
-    gettimeofday(tv, NULL);
-    return tv->tv_sec * 1000000 + tv->tv_usec;
-  }
-
   void start() {
     struct timeval tv;
     unsigned long long t0,t1,t2, t3, t4, t5;
@@ -787,7 +782,11 @@ public:
    * by forwarder
    */
   void gatherDiff(Solver<float>* another) {
+    struct timeval tv;
+    unsigned long long t0,t1,t2, t3, t4, t5;
+    t0 = tick(&tv);
     Lock l(mu_diff);
+    t1 = tick(&tv);
     for(int i = 0; i < another->net()->params().size(); i++){
       auto acc = (*diffBlobFront)[i];
       auto blob = another->net()->params()[i];
@@ -809,6 +808,10 @@ public:
     diffCount++;
     if(diffCount >= FLAGS_pushstep) {
       signalPush();
+    }
+    t2 = tick(&tv);
+    if(t2 - t0 > 100000){
+      LL << "long accumulate diff:\tlock\t" << (t1-t0) << "\tadd\t" << (t2-t1);
     }
   }
 

--- a/src/app/caffe/caffe_async_share.cc
+++ b/src/app/caffe/caffe_async_share.cc
@@ -284,7 +284,8 @@ class NetForwarder {
 public:
   NetForwarder(CaffeWorker* parent, int id, string workerRoot, bool display):
     id(id),worker(parent),rootDir(workerRoot),
-    solver(nullptr),weightVersion(-1),start_forward(false),needDisplay(display){
+    solver(nullptr),weightVersion(-1),wantedVersion(0),
+    start_forward(false),needDisplay(display){
   }
 
   /**

--- a/src/app/caffe/caffe_async_share.cc
+++ b/src/app/caffe/caffe_async_share.cc
@@ -491,12 +491,12 @@ public:
     pullIterations();
     for (int i = 0; i < iter; i++) {
       t0 = tick(&tv);
-      tryCopyWeight();
-      t1 = tick(&tv);
       // wait signal to forward
       if(needDisplay){
         solver->testPhase();
       }
+      t1 = tick(&tv);
+      tryCopyWeight();
       t2 = tick(&tv);
 //      LL<< "forwarder # " << id;
       solver->forwardBackwardPhase();
@@ -510,8 +510,8 @@ public:
       // bypass all of computeUpdateValue
       solver->stepEnd();
       /*
-      LL << "# " << id << "\ttryCopyWeight\t"<< (t1-t0)
-              << "\ttestPhase\t"<< (t2-t1)
+      LL << "# " << id << "\ttestPhase\t"<< (t1-t0)
+              << "\ttryCopyWeight\t"<< (t2-t1)
               << "\tforwardBackward\t"<< (t3-t2)
               << "\taccumulateDiff\t"<< (t4-t3)
               << "\tdisplayPhase\t"<< (t5-t4);

--- a/src/app/caffe/caffe_async_share.cc
+++ b/src/app/caffe/caffe_async_share.cc
@@ -845,7 +845,14 @@ public:
     diffs->waitOutMsg(kServerGroup, push_time);
     //clear previous diff
     for(auto acc : (*diffBlobBack)){
-      memset(acc->mutable_cpu_diff(), 0, acc->diff()->size());
+      switch(Caffe::mode()){
+        case Caffe::CPU:
+          memset(acc->mutable_cpu_diff(), 0, acc->diff()->size());
+          break;
+        case Caffe::GPU:
+          caffe_gpu_set(acc->count(), (float)0, acc->mutable_gpu_diff());
+          break;
+      }
     }
 
     LL << "Worker diff pushed to server";

--- a/src/app/caffe/caffe_async_share.cc
+++ b/src/app/caffe/caffe_async_share.cc
@@ -105,7 +105,7 @@ static std::mutex mu_pwd;
 Solver<float>* initCaffeSolverInDir(int id, string root){
   Lock l(mu_pwd);
   char* cwd = getcwd(nullptr,1024);
-  LL << "cwd: " << cwd;
+  LL << "previous cwd: " << cwd << " root: " << root;
   CHECK(cwd != nullptr);
   CHECK(0 == chdir(root.c_str()));
   Solver<float>* solver = initCaffeSolver(id);
@@ -155,7 +155,10 @@ class CaffeServer : public App, public VVListener<float>, public VVListener<char
 
   void run() {
     LL << myNodeID() << ", server " << myRank() << " run()ing";
-
+    while(true){
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    LL << myNodeID() << ", server " << myRank() << " over";
   }
 
   void process(const MessagePtr& msg) {
@@ -567,6 +570,9 @@ public:
    */
   void run(){
     LL << "worker run()";
+    while(true){
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
     LL << "worker run() over";
   }
 
@@ -742,6 +748,7 @@ int main(int argc, char *argv[]) {
   sys.start(&argc, &argv);
 
   sys.stop();
+  LL << "system exit";
   return 0;
 }
 

--- a/src/app/caffe/caffe_async_share.cc
+++ b/src/app/caffe/caffe_async_share.cc
@@ -536,10 +536,12 @@ public:
   void waitPushSignal(){
     std::unique_lock<std::mutex> l(mu_push);
     cv_push.wait(l);
+    LL << "push signal received: " << diffCount;
   }
 
   void signalPush(){
     std::unique_lock<std::mutex> l(mu_push);
+    LL << "signal push on: " << diffCount;
     cv_push.notify_all();
   }
 
@@ -549,10 +551,12 @@ public:
   void waitPullSignal(){
     std::unique_lock<std::mutex> l(mu_pull);
     cv_pull.wait(l);
+    LL << "pull signal received: " << requestedVersion << " vs " << weightVersion;
   }
 
   void signalPull(){
     std::unique_lock<std::mutex> l(mu_pull);
+    LL << "signal pull on: " << requestedVersion << " vs " << weightVersion;
     cv_pull.notify_all();
   }
 

--- a/src/app/caffe/caffe_async_share.cc
+++ b/src/app/caffe/caffe_async_share.cc
@@ -302,6 +302,9 @@ class CaffeServer : public App, public VVListener<float>, public VVListener<char
     solver->snapshotPhase();
     solver->stepEnd();
 
+    for (auto blob : (*diffBlobBack)){
+      memset(blob->mutable_cpu_diff(), 0, blob->diff()->size());
+    }
     signalUpdateEnd();
   }
 

--- a/src/app/caffe/caffe_main.cc
+++ b/src/app/caffe/caffe_main.cc
@@ -1,0 +1,451 @@
+#include <iostream>
+#include <chrono>
+#include <thread>
+
+#include "ps.h"
+#include "system/app.h"
+#include "parameter/v_vector.h"
+#include "parameter/kv_vector.h"
+#include "caffe/caffe.hpp"
+using caffe::Blob;
+using caffe::Solver;
+using caffe::SolverParameter;
+using caffe::Caffe;
+
+// caffe cmd flags
+
+DEFINE_int32(gpu, -1,
+    "Run in GPU mode on given device ID.");
+DEFINE_string(solver, "",
+    "The solver definition protocol buffer text file.");
+DEFINE_string(model, "",
+    "The model definition protocol buffer text file..");
+DEFINE_string(snapshot, "",
+    "Optional; the snapshot solver state to resume training.");
+
+// client puller / pusher flags
+
+DEFINE_int32(pullstep, 1,
+    "interval, in minibatches, between pull operation.");
+DEFINE_int32(pushstep, 1,
+    "interval, in minibatches, between push operation.");
+
+
+
+caffe::SolverParameter solver_param;
+Solver<float>* initCaffeSolver(){
+
+  Solver<float>* solver;
+
+  CHECK_GT(FLAGS_solver.size(), 0) << "Need a solver definition to train.";
+
+  caffe::ReadProtoFromTextFileOrDie(FLAGS_solver, &solver_param);
+
+  if (FLAGS_gpu < 0
+      && solver_param.solver_mode() == caffe::SolverParameter_SolverMode_GPU) {
+    FLAGS_gpu = solver_param.device_id();
+  }
+
+  // Set device id and mode
+  if (FLAGS_gpu >= 0) {
+    LOG(INFO) << "Use GPU with device ID " << FLAGS_gpu;
+    Caffe::SetDevice(FLAGS_gpu);
+    Caffe::set_mode(Caffe::GPU);
+  } else {
+    LOG(INFO) << "Use CPU.";
+    Caffe::set_mode(Caffe::CPU);
+  }
+
+  solver = caffe::GetSolver<float>(solver_param);
+
+  if (FLAGS_snapshot.size()) {
+    LOG(INFO) << "Resuming from " << FLAGS_snapshot;
+    solver->Restore(FLAGS_snapshot.c_str());
+  }
+
+  return solver;
+}
+
+#define V_WEIGHT "w"
+#define V_DIFF "d"
+namespace PS {
+class CaffeServer : public App, public VVListener<float> {
+ public:
+  CaffeServer(const string& name, const string& conf) : App(name) { }
+  virtual ~CaffeServer() { }
+
+  virtual void init() {
+    LL << myNodeID() << ", this is server " << myRank();
+
+    solver = initCaffeSolver();
+
+    // initialize the weight at server
+    weights = new VVector<float>(V_WEIGHT, true);
+    diffs = new VVector<float>(V_DIFF, false, this);
+    for (int i = 0; i < solver->net()->params().size();i++){
+	auto blob = solver->net()->params()[i];
+	weights->value(i).reset(blob->mutable_cpu_data(), blob->count(), false);
+	Blob<float>* newBlob = new Blob<float>(blob->num(), blob->channels(), blob->height(), blob->width());
+	diffBlobs.push_back(newBlob);
+	diffs->value(i).reset(newBlob->mutable_cpu_diff(), newBlob->count(), false);
+    }
+  }
+  
+  void run() {
+    LL << myNodeID() << ", server " << myRank() << " run()ing";
+    int nextTest=0,nextSnapshot=0;
+    auto param = solver->param();
+    bool needTest = param.test_interval() > 0;
+    bool needSnapshot = param.snapshot() > 0;
+    if(needTest){
+      nextTest = solver->iter() - solver->iter() % param.test_interval() + param.test_interval();
+    }
+    if(needSnapshot){
+      nextSnapshot = solver->iter() - solver->iter() % param.snapshot() + param.snapshot();
+    }
+    while(true){
+      LL << "server looping: iter " << solver->iter() << " vs test " << nextTest << " vs snapshot " << nextSnapshot;
+      if (needTest && solver->iter() >= nextTest) {
+	nextTest = solver->iter() - solver->iter() % param.test_interval() + param.test_interval();
+	solver->TestAll();
+      }
+      //no loss to display at server
+      if (needSnapshot && solver->iter() >= nextSnapshot) {
+	nextSnapshot = solver->iter() - solver->iter() % param.snapshot() + param.snapshot();
+	solver->Snapshot();
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+  }
+
+  void process(const MessagePtr& msg) {
+    LL << "message received!";
+    auto sgd = msg->task.sgd();
+    if (sgd.cmd() == SGDCall::SAVE_MODEL) { // sync param to memory
+	{
+	  Lock l(mu_solver);
+	    for (int i = 0; i < solver->net()->params().size();i++){
+		auto blob = solver->net()->params()[i];
+		blob->cpu_data();
+	    }
+	}
+    }
+  }
+
+  void vectorChanged(VVector<float>* data){
+    //TODO copy diff into net->params->diff, and compute weight update
+    LL << "vector change received:" << data->name();
+    CHECK_EQ(data, this->diffs) << "server only accept diff changes";
+
+    Lock l(mu_solver);
+    float first,last, firstv, lastv;
+    for (int i = 0; i < solver->net()->params().size();i++){
+      auto blob = solver->net()->params()[i];
+      float* dest = blob->mutable_cpu_diff();
+      auto src = diffs->value(i);
+      memcpy(dest, src.data(), blob->diff()->size());
+      if(i==0){
+	  first=blob->cpu_diff()[0];
+	  firstv = src[0];
+      }else if(i == solver->net()->params().size()-1){
+	  last=blob->cpu_diff()[blob->count()-1];
+	  lastv = src[src.size() - 1];
+      }
+    }
+//    LL<< "got diff[" << first<<",...,"<<last<<"]/[" << firstv << ",...," << lastv <<"]";
+
+    solver->ComputeUpdateValue();
+    solver->net()->Update();
+    solver->snapshotPhase();
+    solver->stepEnd();
+
+ }
+
+
+ private:
+  VVector<float> *weights; //share data ptr with solver->net->params->cpu_data
+  VVector<float> *diffs; //individual data ptr with diffBlobs
+  std::vector<Blob<float>*> diffBlobs;
+
+  std::mutex mu_solver;
+  caffe::Solver<float>* solver;
+};
+
+App* CreateServerNode(const std::string& conf) {
+  return new CaffeServer("app", conf);
+}
+
+
+class CaffeWorker: public App{
+private:
+
+  std::mutex mu_weight; // protect write to weight_ready and weights
+  volatile bool weight_ready;
+  std::mutex mu_diff;  //protect write to diffs
+
+  VVector<float> *weights;// individual data ptr, same order/size as solver->net->params
+  VVector<float> *diffs;// for accumulated diff, share memory with diffBlobs
+  std::vector<Blob<float>*> diffBlobs;
+  caffe::Solver<float>* solver;
+
+  std::unique_ptr<std::thread> pusher;
+  std::unique_ptr<std::thread> puller;
+
+  volatile unsigned int tickDiff=0, tickStep=0;
+
+  volatile bool _terminate = false;
+
+public:
+  CaffeWorker(const string& name, const string& conf):App(name){
+
+  }
+  ~CaffeWorker(){
+    if(pusher){
+	pusher->join();
+    }
+    if(puller){
+	puller->join();
+    }
+  }
+
+  void init(){
+    solver = initCaffeSolver();
+    //init shared parameter at worker
+    weights = new VVector<float>(V_WEIGHT);
+    diffs = new VVector<float>(V_DIFF);
+    for (int i = 0; i < solver->net()->params().size();i++){
+      auto blob = solver->net()->params()[i];
+      weights->value(i).resize(blob->count());
+      Blob<float>* newBlob = new Blob<float>(blob->num(), blob->channels(), blob->height(), blob->width());
+      diffBlobs.push_back(newBlob);
+      diffs->value(i).reset(newBlob->mutable_cpu_diff(), newBlob->count(), false);
+    }
+
+  }
+
+  /**
+   * by main
+   */
+  void run(){
+    LL << "worker run()";
+    //initial pull from server
+    pullWeight();
+    swapWeight();
+
+    // start pusher/puller
+    pusher = std::unique_ptr<std::thread>(new std::thread(&CaffeWorker::pusherMain, this));
+    puller = std::unique_ptr<std::thread>(new std::thread(&CaffeWorker::pullerMain, this));
+
+    // start training loop
+    int iter = solver->param().max_iter() - solver->iter();
+    LL << "start training loop";
+    for (int i = 0; i < iter; i++) {
+	//solver->OneStep()
+      swapWeight();
+      solver->testPhase();
+      solver->forwardBackwardPhase();
+      this->accumulateDiff();
+      solver->displayPhase();
+      solver->ComputeUpdateValue();
+      solver->net()->Update();
+      solver->snapshotPhase();
+      solver->stepEnd();
+      stepEnd();
+    }
+    // If we haven't already, save a snapshot after optimization, unless
+    // overridden by setting snapshot_after_train := false
+    if (solver->param().snapshot_after_train()
+        && (!solver->param().snapshot() || solver->iter() % solver->param().snapshot() != 0)) {
+      solver->Snapshot();
+    }
+    // After the optimization is done, run an additional train and test pass to
+    // display the train and test loss/outputs if appropriate (based on the
+    // display and test_interval settings, respectively).  Unlike in the rest of
+    // training, for the train net we only run a forward pass as we've already
+    // updated the parameters "max_iter" times -- this final pass is only done to
+    // display the loss, which is computed in the forward pass.
+    if (solver->param().display() && solver->iter() % solver->param().display() == 0) {
+      float loss;
+      solver->net()->ForwardPrefilled(&loss);
+      LOG(INFO) << "Iteration " << solver->iter() << ", loss = " << loss;
+    }
+    if (solver->param().test_interval() && solver->iter() % solver->param().test_interval() == 0) {
+      solver->TestAll();
+    }
+    terminate();
+  }
+
+  /**
+   * notify accumulateDiff end, for pusher counting
+   */
+  void diffEnd(){
+    tickDiff++;
+  }
+
+  void stepEnd(){
+    tickStep++;
+  }
+
+  void terminate(){
+    _terminate = true;
+    //TODO tell server I'm done
+  }
+
+  void pusherMain(){
+    LL << "pusher start";
+    int nextTick = tickDiff - tickDiff % FLAGS_pushstep + FLAGS_pushstep;
+    while(!_terminate){
+//	LL << "pusher check " << tickDiff;
+	if(this->tickDiff >= nextTick){
+	    nextTick = tickDiff - tickDiff % FLAGS_pushstep + FLAGS_pushstep;
+	    pushDiff();
+	}
+	std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    LL << "pusher exit";
+  }
+
+  void pullerMain(){
+    LL << "puller start";
+    int nextTick = tickStep - tickStep % FLAGS_pullstep + FLAGS_pullstep;
+    while(!_terminate){
+//	LL << "puller check " << tickStep << " vs " << nextTick;
+	if(this->tickStep >= nextTick){
+	    nextTick = tickStep - tickStep % FLAGS_pullstep + FLAGS_pullstep;
+	    pullWeight();
+	}
+	std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    LL << "puller exit";
+  }
+
+  /**
+   * by pusher, synchronized (block until message sent)
+   */
+  void pushDiff(){
+    Lock l(mu_diff);
+    //push to app instead of
+    MessagePtr msg(new Message(kServerGroup));
+    msg->key = {0};
+    msg->task.set_key_channel(0);
+    float first,last, firstv, lastv;
+    for(int i = 0; i < diffs->vcount();i++){
+	auto acc = diffBlobs[i];
+	acc->cpu_diff(); // sync to cpu
+	auto diff = diffs->value(i);
+	CHECK_EQ(acc->cpu_diff(), diff.data());
+	msg->addValue(diff);
+	if(i == 0){
+	    first = acc->cpu_diff()[0];
+	    firstv = diff[0];
+	}else if(i == diffs->vcount()-1){
+	    last = acc->cpu_diff()[acc->count()-1];
+	    lastv = diff[diff.size() - 1];
+	}
+    }
+    int push_time = diffs->push(msg);
+    diffs->waitOutMsg(kServerGroup, push_time);
+//    LL<< "pushed diff[" << first<<",...,"<<last<<"]/[" << firstv << ",...," << lastv <<"]";
+    //clear previous diff
+    for(auto acc : diffBlobs){
+	memset(acc->mutable_cpu_diff(), 0, acc->diff()->size());
+    }
+  }
+
+  /**
+   * by main
+   */
+  void accumulateDiff(){
+    {
+      Lock l(mu_diff);
+      for(int i = 0; i < solver->net()->params().size(); i++){
+	auto acc = diffBlobs[i];
+	auto blob = solver->net()->params()[i];
+	switch (Caffe::mode()) {
+	case Caffe::CPU:
+	  caffe::caffe_add(acc->count(), blob->cpu_diff(), acc->cpu_diff(), acc->mutable_cpu_diff());
+	  break;
+	case Caffe::GPU:
+	  caffe::caffe_gpu_add(acc->count(), blob->gpu_diff(), acc->gpu_diff(), acc->mutable_gpu_diff());
+	  break;
+	default:
+	  LOG(FATAL) << "Unknown caffe mode: " << Caffe::mode();
+	}
+      }
+    }
+    diffEnd();
+  }
+
+  /**
+   * by puller (except the initial pull), synchronized
+   */
+  void pullWeight(){
+    Task task;
+    task.mutable_sgd()->set_cmd(SGDCall::UPDATE_MODEL);
+    port(kServerGroup)->submitAndWait(task);
+
+    Lock l(mu_weight);
+    if(weight_ready){
+	return;
+    }
+    MessagePtr msg(new Message(kServerGroup));
+    msg->key = {0};
+    int pull_time = weights->pull(msg);
+    weights->waitOutMsg(kServerGroup, pull_time);
+    weight_ready = true;
+    LL << "weight pulled from server, total:" << weights->totalSize();
+  }
+  /**
+   * by main, copy received weight into solver->net
+   */
+  void swapWeight(){
+    Lock l(mu_weight);
+    if(!weight_ready){
+      return;
+    }
+    for (int i = 0; i < solver->net()->params().size();i++){
+      auto blob = solver->net()->params()[i];
+      float* dest = blob->mutable_cpu_data();
+      auto src = weights->value(i);
+      memcpy(dest, src.data(), blob->data()->size());
+      //TODO direct copy to GPU?
+    }
+    weight_ready = false;
+  }
+};
+} // namespace PS
+
+namespace PS {
+App* App::create(const string& name, const string& conf) {
+  auto my_role = Postoffice::instance().myNode().role();
+  if (my_role == Node::SERVER) {
+    return new CaffeServer(name, conf);
+  } else if(my_role == Node::WORKER){
+      return new CaffeWorker(name, conf);
+  }else{
+    return new App();
+  }
+}
+} // namespace PS
+
+
+int main(int argc, char *argv[]) {
+
+  google::ParseCommandLineFlags(&argc, &argv, true);
+
+  auto& sys = PS::Postoffice::instance();
+  sys.start(&argc, &argv);
+//
+//  int ret = 0;
+//  if (sys.myNode().role() == PS::Node::WORKER) {
+//      using namespace PS;
+//      LOG(ERROR) << MyNodeID() <<  ": this is worker " << MyRank();
+//      {
+//	ret = CaffeWorker().start();
+//      }
+//  }
+
+  sys.stop();
+  return 0;
+}
+

--- a/src/app/caffe/caffe_main.cc
+++ b/src/app/caffe/caffe_main.cc
@@ -104,7 +104,7 @@ class CaffeServer : public App, public VVListener<float> {
       nextSnapshot = solver->iter() - solver->iter() % param.snapshot() + param.snapshot();
     }
     while(true){
-      LL << "server looping: iter " << solver->iter() << " vs test " << nextTest << " vs snapshot " << nextSnapshot;
+//    LL << "server looping: iter " << solver->iter() << " vs test " << nextTest << " vs snapshot " << nextSnapshot;
       if (needTest && solver->iter() >= nextTest) {
 	nextTest = solver->iter() - solver->iter() % param.test_interval() + param.test_interval();
 	solver->TestAll();
@@ -216,6 +216,15 @@ public:
   }
 
   void init(){
+
+  }
+
+  /**
+   * by main
+   */
+  void run(){
+    LL << "worker run()";
+
     solver = initCaffeSolver();
     //init shared parameter at worker
     weights = new VVector<float>(V_WEIGHT);
@@ -228,13 +237,6 @@ public:
       diffs->value(i).reset(newBlob->mutable_cpu_diff(), newBlob->count(), false);
     }
 
-  }
-
-  /**
-   * by main
-   */
-  void run(){
-    LL << "worker run()";
     //initial pull from server
     pullWeight();
     swapWeight();

--- a/src/app/caffe/caffe_share.cc
+++ b/src/app/caffe/caffe_share.cc
@@ -413,7 +413,7 @@ public:
         solver->stepEnd();
       }
       LL << "pushstep " << FLAGS_pushstep << " reached.";
-      LL << "run() sending forward end signal";
+      LL << "Forwarder sending forward end signal";
       signalForwardEnd();
     }
   }
@@ -562,7 +562,7 @@ public:
       }
       LL << "all forwarder joined: " << forwarders.size();
       pushDiff();
-      LL << "run() sending forward end signal";
+      LL << "Worker sending forward end signal";
       signalForwardEnd();
     }
     LL << "worker run() over";

--- a/src/app/caffe/caffe_share.cc
+++ b/src/app/caffe/caffe_share.cc
@@ -429,7 +429,6 @@ public:
         if(needDisplay){
           solver->testPhase();
         }
-        LL<< "forwarder # " << id;
         solver->forwardBackwardPhase();
         this->accumulateDiff();
         if(needDisplay){

--- a/src/app/caffe/caffe_share.cc
+++ b/src/app/caffe/caffe_share.cc
@@ -403,8 +403,7 @@ public:
         if(needDisplay){
           solver->testPhase();
         }
-        LL<< "forwarder # " << id << " DeviceQuery";
-        Caffe::DeviceQuery();
+        LL<< "forwarder # " << id;
         solver->forwardBackwardPhase();
         this->accumulateDiff();
         if(needDisplay){

--- a/src/app/caffe/caffe_share.cc
+++ b/src/app/caffe/caffe_share.cc
@@ -449,7 +449,6 @@ class CaffeWorker: public App{
 private:
 
   std::mutex mu_weight; // protect write to weight_ready and weights
-  volatile bool weight_ready;
   std::mutex mu_diff;  //protect write to diffs
 
 
@@ -476,7 +475,6 @@ public:
 
   void init(){
     LL << "worker init()";
-    weight_ready = false;
     start_forward = false;
     solver = initCaffeSolver(-1);
     //init shared parameter at worker
@@ -626,17 +624,12 @@ public:
 //    port(kServerGroup)->submitAndWait(task);
 
     Lock l(mu_weight);
-    if(weight_ready){
-      LL << "weight_ready!";
-      return;
-    }
     MessagePtr msg(new Message(kServerGroup));
     msg->key = {0};
     LL << "begin pull";
     int pull_time = weights->pull(msg);
     LL << "begin waitOutMsg";
     weights->waitOutMsg(kServerGroup, pull_time);
-    weight_ready = true;
     LL << "weight pulled from server, total:" << weights->totalSize();
   }
 

--- a/src/app/caffe/caffe_share.cc
+++ b/src/app/caffe/caffe_share.cc
@@ -12,6 +12,8 @@
 #include "caffe/common.hpp"
 #include "caffe/util/math_functions.hpp"
 #include "caffe/util/upgrade_proto.hpp"
+#include "app/caffe/util.h"
+
 using namespace caffe;
 using namespace std;
 using caffe::Blob;
@@ -112,20 +114,6 @@ Solver<float>* initCaffeSolverInDir(int id, string root){
   return solver;
 }
 
-void checkNAN(int count, const float* data, string blobName){
-  bool isNan = false;
-  int nanIndex = -1;
-  for (int j = 0; j < count; j++){
-    if(isnan(data[j])){
-      isNan = true;
-      nanIndex = j;
-    }
-  }
-  if(isNan){
-    LL << "NAN in "<< blobName <<"[" << nanIndex << "]!";
-  }
-
-}
 
 class CaffeServer : public App, public VVListener<float>, public VVListener<char> {
  public:

--- a/src/app/caffe/caffe_share.cc
+++ b/src/app/caffe/caffe_share.cc
@@ -257,7 +257,7 @@ class CaffeServer : public App, public VVListener<float>, public VVListener<char
       //check
       ostringstream nameSt;
       nameSt << "diffBlob[" << i <<"]";
-      checkNAN(blob->count(), diffBlobs[i]->cpu_diff(), nameSt.str());
+//      checkNAN(blob->count(), diffBlobs[i]->cpu_diff(), nameSt.str());
       //scale down?
       if(FLAGS_pushstep != 0){
         caffe::caffe_scal(blob->count(), float(1.0 / FLAGS_pushstep), src);
@@ -613,7 +613,7 @@ public:
       auto blob = another->net()->params()[i];
       ostringstream name;
       name << "gatherDiff:solver.blobs[" << i << "]";
-      checkNAN(blob->count(), blob->cpu_diff(), name.str());
+//      checkNAN(blob->count(), blob->cpu_diff(), name.str());
       caffe::caffe_add(acc->count(), blob->cpu_diff(), acc->cpu_diff(), acc->mutable_cpu_diff());
     }
   }

--- a/src/app/caffe/caffe_share.cc
+++ b/src/app/caffe/caffe_share.cc
@@ -352,7 +352,8 @@ class NetForwarder {
 
 public:
   NetForwarder(CaffeWorker* parent, int id, string workerRoot, bool display):
-    id(id),worker(parent),rootDir(workerRoot),solver(nullptr),needDisplay(display){
+    id(id),worker(parent),rootDir(workerRoot),
+    solver(nullptr),start_forward(false),needDisplay(display){
   }
 
   /**

--- a/src/app/caffe/caffe_synced.cc
+++ b/src/app/caffe/caffe_synced.cc
@@ -28,6 +28,10 @@ DEFINE_string(snapshot, "",
     "Optional; the snapshot solver state to resume training.");
 
 
+DEFINE_bool(fb_only, true,
+    "DEPRECATED; workers only ForwardBackward.");
+DEFINE_bool(synced, false,
+    "DEPRECATED; pull/push synced with Forward");
 // client puller / pusher flags
 DEFINE_int32(pushstep, 3,
     "interval, in minibatches, between push operation.");

--- a/src/app/caffe/caffe_synced.cc
+++ b/src/app/caffe/caffe_synced.cc
@@ -10,6 +10,7 @@
 #include "caffe/caffe.hpp"
 #include "caffe/util/math_functions.hpp"
 #include "caffe/util/upgrade_proto.hpp"
+#include "app/caffe/util.h"
 using caffe::Blob;
 using caffe::Solver;
 using caffe::SolverParameter;
@@ -476,6 +477,9 @@ public:
       for(int i = 0; i < solver->net()->params().size(); i++){
         auto acc = diffBlobs[i];
         auto blob = solver->net()->params()[i];
+        ostringstream name;
+        name << "accumulateDiff:net.params[" << i << "].diff";
+        checkNAN(blob->count(), blob->cpu_diff(), name.str());
         switch (Caffe::mode()) {
           case Caffe::CPU:
             caffe::caffe_add(acc->count(), blob->cpu_diff(), acc->cpu_diff(), acc->mutable_cpu_diff());

--- a/src/app/caffe/util.h
+++ b/src/app/caffe/util.h
@@ -1,0 +1,33 @@
+/*
+ * util.h
+ *
+ *  Created on: Apr 21, 2015
+ *      Author: immars
+ */
+
+#ifndef SRC_APP_CAFFE_UTIL_H_
+#define SRC_APP_CAFFE_UTIL_H_
+#include <iostream>
+#include <google/protobuf/io/coded_stream.h>
+#include <glog/logging.h>
+#include "util/common.h"
+
+using namespace std;
+
+void checkNAN(int count, const float* data, string blobName){
+  bool isNan = false;
+  int nanIndex = -1;
+  int nanCount = 0;
+  for (int j = 0; j < count; j++){
+    if(isnan(data[j])){
+      isNan = true;
+      nanIndex = j;
+      nanCount++;
+    }
+  }
+  if(isNan){
+    LL << nanCount << "NANs in "<< blobName <<"[" << nanIndex << "]!";
+  }
+}
+
+#endif /* SRC_APP_CAFFE_UTIL_H_ */

--- a/src/app/caffe/util.h
+++ b/src/app/caffe/util.h
@@ -30,4 +30,9 @@ void checkNAN(int count, const float* data, string blobName){
   }
 }
 
+inline unsigned long long tick(struct timeval* tv) {
+  gettimeofday(tv, NULL);
+  return tv->tv_sec * 1000000 + tv->tv_usec;
+}
+
 #endif /* SRC_APP_CAFFE_UTIL_H_ */

--- a/src/parameter/v_vector.h
+++ b/src/parameter/v_vector.h
@@ -1,0 +1,127 @@
+#pragma once
+#include "Eigen/Dense"
+#include "parameter/shared_parameter.h"
+#include "util/parallel_ordered_match.h"
+#include "caffe/util/math_functions.hpp"
+namespace PS {
+
+template<typename V> class VVector;
+template<typename V> using VVectorPtr = std::shared_ptr<VVector<V>>;
+
+
+#define USING_SHARED_PARAMETER_INT8             \
+  using Customer::port;                         \
+  using Customer::myNodeID;                     \
+  using SharedParameter<uint8>::get;                \
+  using SharedParameter<uint8>::set;                \
+  using SharedParameter<uint8>::myKeyRange;         \
+  using SharedParameter<uint8>::keyRange;           \
+  using SharedParameter<uint8>::sync
+
+using caffe::caffe_copy;
+using caffe::caffe_add;
+
+// value vector only, access entirely ignoring keys/key ranges. key default to 0.
+// values are stored in arrays.
+
+template <typename V>
+class VVListener{
+public:
+  virtual void vectorChanged(VVector<V>* data) = 0;
+  virtual ~VVListener() {};
+};
+
+template <typename V>
+class VVector : public SharedParameter<uint8> {
+ public:
+  VVector(const string& my_name, bool readonly = false, VVListener<V>* listener = nullptr, const string& parent_name = FLAGS_app_name, int k = 1) :
+      SharedParameter<uint8>(my_name, parent_name), val_entry_size_(k) {
+    this->listener = listener;
+    this->readonly = readonly;
+  }
+  // VVector() : val_entry_size_(1) { }
+  // VVector(int k) : val_entry_size_(k) { }
+  virtual ~VVector() { }
+
+  SArray<V>& value(int block_index = 0) { Lock l(mu_); return val_[block_index]; }
+  void clear(int channel = 0) { Lock l(mu_); val_.erase(channel); }
+
+  // find the local positions of a global key range
+//  SizeR find(int channel, const Range<K>& key_range) {
+//    return key(channel).findRange(key_range);
+//  }
+
+  int valueEntrySize() const { return val_entry_size_; }
+
+  int vcount() {return this->val_.size();}
+
+  int totalSize() {
+    int sum = 0;
+    for(int i = 0; i < val_.size(); i++){
+	auto v = value(i);
+	sum += v.size();
+    }
+    return sum;
+  }
+  // functions will used by the system
+  MessagePtrList slice(const MessagePtr& msg, const KeyRangeList& sep);
+  void getValue(const MessagePtr& msg);
+  void setValue(const MessagePtr& msg);
+
+  USING_SHARED_PARAMETER_INT8;
+ protected:
+  std::mutex mu_;
+  std::unordered_map<int, SArray<V>> val_;
+  int val_entry_size_;
+
+  VVListener<V>* listener;
+  bool readonly;
+};
+
+template <typename V>
+void VVector<V>::setValue(const MessagePtr& msg) {
+  CHECK(!readonly) << "VVector[" << name() << "] is read only!";
+//  LL << "VVector::setValue received";
+  // do check
+  CHECK_EQ(msg->value.size(), val_.size()) << "my size(" << val_.size() << ") != message size(" << msg->value.size() << ")";
+  for(int i = 0; i < msg->value.size(); i++){
+      SArray<V> recv_val(msg->value[i]);
+      auto& my_val = value(i);
+      if (get(msg).has_tail_filter() || get(msg).gather()) {
+        // join the received data with my current data
+        SArray<V> new_val;
+        if (recv_val.empty()) {
+          CHECK(my_val.empty());
+        } else {
+          LL << "VVector::setValue before caffe_add";
+          caffe::caffe_add(recv_val.size(), recv_val.data(), my_val.data(), my_val.data());
+        }
+      } else {
+        CHECK_EQ(my_val.size(), recv_val.size()) << "VVector only support receiving whole VVector";
+        my_val.copyFrom(recv_val);
+      }
+  }
+  if(listener){
+      listener->vectorChanged(this);
+  }
+//  LL << "VVector::setValue leaved";
+}
+
+template <typename V>
+void VVector<V>::getValue(const MessagePtr& msg) {
+//  LL << "VVector::getValue received";
+  // get the data
+  msg->clearValue();
+  for(int i = 0; i < val_.size(); i++){
+      msg->addValue(this->value(i));
+  }
+}
+
+// partition is a sorted key ranges
+template <typename V>
+MessagePtrList VVector<V>::slice(const MessagePtr& msg, const KeyRangeList& sep) {
+  if (get(msg).replica()) return Customer::slice(msg, sep);
+  return sliceKeyOrderedMsg<uint8>(msg, sep);
+}
+
+} // namespace PS


### PR DESCRIPTION
Caffe Integration attempt with parameter_server.
This pull request is created not because the code is ready for merge, but to draw attention and ask questions to get make implementation. Thanks.

about algorithm
* follow google's nips 2012 Downpour SGD approach
* workers do Forward/Backward only, server updates parameters
* Adadelta with momentum SGD is tested to produce good convergence

about implementation
* uses push/pull as communication frameworks
* `src/app/caffe/caffe_main.cc`: 1 process per gpu device; computation drived by workers; puller/pusher/solver in different thread
* `src/app/caffe/caffe_async.cc`: 1 process per gpu device; computation drived by server; all workers compute a batch and those batches accumulated to a larger batch, effectively a N times larger batch-size
* `src/app/caffe/caffe_async_share.cc`: 1 process per node, 1 thread per gpu device; weights pulled from server are shared by threads; computation drived by workers 
* tested with 2 nodes with 4 gpu devices each. `caffe_async_share` gets better performance overall w.r.t. network usage/convergence speed

about usage:
* `script/caffe_local.sh` for test ( not with `caffe_async_share` ), `script/caffe_lan.sh` for launch in cluster
* `script/caffe_kill_lan.sh` for (ungracefully) shutdown in cluster. 
* `caffe_lan.sh` usage: `script/caffe_lan.sh {conf_file}`. See `./conf/` for example conf_file setting up workers/servers.

**Pending questions about code**
* probably not going to be merged, at least not before following issues solved: 
* haven't rebased to current master yet
* Is there a better way notifying server of worker's `push` and `pull`? like `vectorChanged` `vectorChanging` interfaces introduced in my code. Server need to update weights after worker's diff `push`ed, and to synchronize weights from gpu back to host memory just before worker `pull`.
* Is there document explaining `SharedParameter`, its subclasses, channels, and their usage in the cluster? `VVector` added for simpler implementation: all parameters in one un-dividable vector (only 1 server supported as a result) but I guess that could be replaced by KVVector to support multi-servers. I just don't know how.

